### PR TITLE
Suggestion: Add a link to a site for retrieving the YouTube video ID

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -30,6 +30,6 @@ Whether you're hanging out, studying, or just vibing, LiveTune ensures that ever
 - Click Request sync to match everyone's timestamp same to the host's
 - Send Message button currently has no use for now.
 - If you click Ping button repeatedly, you have a chance to get better synced timestamp :)
-- 
+  
 ![image](https://github.com/user-attachments/assets/52d3983c-a1b1-4b27-9a0b-9b43d510c51d)
 - If you joined to the room that was created by others, you have to click 'Request sync' to match your timestamp with the host.

--- a/profile/README.md
+++ b/profile/README.md
@@ -22,7 +22,7 @@ Whether you're hanging out, studying, or just vibing, LiveTune ensures that ever
 
 ![image](https://github.com/user-attachments/assets/437e8914-60a9-4c96-ac49-4b99a5c3aeda)
 - You can enter youtube id, click Add button the add song.
-    - You can get youtube video id from [here](https://commentpicker.com/youtube-video-id.php#:~:text=A%20YouTube%20video%20ID%20is%20a%20unique%20identifier,enables%20seamless%20embedding%20of%20YouTube%20videos%20onto%20websites.) 
+    - You can get the YouTube video ID from [this link](https://commentpicker.com/youtube-video-id.php#:~:text=A%20YouTube%20video%20ID%20is%20a%20unique%20identifier,enables%20seamless%20embedding%20of%20YouTube%20videos%20onto%20websites.).
 - Click Load it up to bring predefined example song list.
 - Click **Skip button** to load the song from the queue
 - Click Play button to play the song

--- a/profile/README.md
+++ b/profile/README.md
@@ -22,6 +22,7 @@ Whether you're hanging out, studying, or just vibing, LiveTune ensures that ever
 
 ![image](https://github.com/user-attachments/assets/437e8914-60a9-4c96-ac49-4b99a5c3aeda)
 - You can enter youtube id, click Add button the add song.
+    - You can get youtube video id from [here](https://commentpicker.com/youtube-video-id.php#:~:text=A%20YouTube%20video%20ID%20is%20a%20unique%20identifier,enables%20seamless%20embedding%20of%20YouTube%20videos%20onto%20websites.) 
 - Click Load it up to bring predefined example song list.
 - Click **Skip button** to load the song from the queue
 - Click Play button to play the song


### PR DESCRIPTION
Hello,
This is Yang Hye-eun from Team 4.

I would like to submit this PR, even though there are no explicit contributing guidelines for documentation. I thought it might be helpful to add a link that explains how to get the YouTube video ID, as this concept might not be familiar to users who are less experienced with YouTube.

My suggestion is based on the idea that improving clarity in the documentation can help make the program more accessible to everyone. Therefore, I added the following line:

Line 25:
- You can get the YouTube video ID from [this link](https://commentpicker.com/youtube-video-id.php#:~:text=A%20YouTube%20video%20ID%20is%20a%20unique%20identifier,enables%20seamless%20embedding%20of%20YouTube%20videos%20onto%20websites.).

Thank you very much for your work, and I hope you have a wonderful day!

Best regards,
Yang Hye-eun